### PR TITLE
⚡ Optimize QueryData loop allocation

### DIFF
--- a/pkg/backend/benchmark_test.go
+++ b/pkg/backend/benchmark_test.go
@@ -1,0 +1,90 @@
+package backend
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// mimic the structure of the data in the loop
+var allIssues []map[string]any
+
+func init() {
+	allIssues = make([]map[string]any, 1000)
+	for i := 0; i < 1000; i++ {
+		allIssues[i] = map[string]any{
+			"issueId":   "ID-12345",
+			"name":      "Issue Name",
+			"timestamp": float64(1678886400000),
+			"siteId":    "site-1",
+			"priority":  "P1",
+			"status":    "Open",
+		}
+	}
+}
+
+func BenchmarkAllocInLoop(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		for _, it := range allIssues {
+			getStr := func(k string) string {
+				if v, ok := it[k]; ok && v != nil {
+					if s, ok2 := v.(string); ok2 {
+						return s
+					}
+				}
+				return ""
+			}
+			getNum := func(k string) int64 {
+				if v, ok := it[k]; ok && v != nil {
+					switch x := v.(type) {
+					case float64:
+						return int64(x)
+					case int64:
+						return x
+					case json.Number:
+						n, _ := x.Int64()
+						return n
+					}
+				}
+				return 0
+			}
+
+			_ = getStr("issueId")
+			_ = getStr("name")
+			_ = getNum("timestamp")
+		}
+	}
+}
+
+func getStrHelper(it map[string]any, k string) string {
+	if v, ok := it[k]; ok && v != nil {
+		if s, ok2 := v.(string); ok2 {
+			return s
+		}
+	}
+	return ""
+}
+
+func getNumHelper(it map[string]any, k string) int64 {
+	if v, ok := it[k]; ok && v != nil {
+		switch x := v.(type) {
+		case float64:
+			return int64(x)
+		case int64:
+			return x
+		case json.Number:
+			n, _ := x.Int64()
+			return n
+		}
+	}
+	return 0
+}
+
+func BenchmarkAllocOutLoop(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		for _, it := range allIssues {
+			_ = getStrHelper(it, "issueId")
+			_ = getStrHelper(it, "name")
+			_ = getNumHelper(it, "timestamp")
+		}
+	}
+}

--- a/pkg/backend/datasource.go
+++ b/pkg/backend/datasource.go
@@ -244,47 +244,24 @@ func (d *Datasource) QueryData(ctx context.Context, req *backend.QueryDataReques
 		// 5. Data Transformation: Convert the raw API response into a structured format
 		//    that can be used to build the Grafana data.Frame.
 		for _, it := range allIssues {
-			getStr := func(k string) string {
-				if v, ok := it[k]; ok && v != nil {
-					if s, ok2 := v.(string); ok2 {
-						return s
-					}
-				}
-				return ""
-			}
-			getNum := func(k string) int64 {
-				if v, ok := it[k]; ok && v != nil {
-					switch x := v.(type) {
-					case float64:
-						return int64(x)
-					case int64:
-						return x
-					case json.Number:
-						n, _ := x.Int64()
-						return n
-					}
-				}
-				return 0
-			}
-
-			siteID := getStr("siteId")
+			siteID := getMapStr(it, "siteId")
 			siteName := siteID // Fallback to ID if enrichment is disabled or fails.
 			if name, ok := siteIDToNameMap[siteID]; ok {
 				siteName = name // Use resolved name if available.
 			}
 
 			r := row{
-				TimeMs:   firstNonZero(getNum("timestamp"), getNum("firstOccurredTime"), getNum("startTime")),
-				ID:       firstNonEmpty(getStr("issueId"), getStr("id"), getStr("instanceId")),
-				Title:    firstNonEmpty(getStr("name"), getStr("title"), getStr("issueTitle")),
-				Severity: firstNonEmpty(getStr("priority"), getStr("severity")),
-				Status:   firstNonEmpty(getStr("issueStatus"), getStr("status")),
-				Category: firstNonEmpty(getStr("category"), getStr("type")),
-				Device:   firstNonEmpty(getStr("deviceId"), getStr("deviceIp"), getStr("device")),
-				MAC:      firstNonEmpty(getStr("macAddress"), getStr("clientMac")),
+				TimeMs:   firstNonZero(getMapNum(it, "timestamp"), getMapNum(it, "firstOccurredTime"), getMapNum(it, "startTime")),
+				ID:       firstNonEmpty(getMapStr(it, "issueId"), getMapStr(it, "id"), getMapStr(it, "instanceId")),
+				Title:    firstNonEmpty(getMapStr(it, "name"), getMapStr(it, "title"), getMapStr(it, "issueTitle")),
+				Severity: firstNonEmpty(getMapStr(it, "priority"), getMapStr(it, "severity")),
+				Status:   firstNonEmpty(getMapStr(it, "issueStatus"), getMapStr(it, "status")),
+				Category: firstNonEmpty(getMapStr(it, "category"), getMapStr(it, "type")),
+				Device:   firstNonEmpty(getMapStr(it, "deviceId"), getMapStr(it, "deviceIp"), getMapStr(it, "device")),
+				MAC:      firstNonEmpty(getMapStr(it, "macAddress"), getMapStr(it, "clientMac")),
 				Site:     siteName,
-				Rule:     getStr("ruleId"),
-				Details:  firstNonEmpty(getStr("description"), getStr("details"), getStr("issueDescription")),
+				Rule:     getMapStr(it, "ruleId"),
+				Details:  firstNonEmpty(getMapStr(it, "description"), getMapStr(it, "details"), getMapStr(it, "issueDescription")),
 			}
 			if r.TimeMs == 0 {
 				r.TimeMs = q.TimeRange.From.UnixMilli()
@@ -538,6 +515,32 @@ func firstNonZero(vals ...int64) int64 {
 	for _, v := range vals {
 		if v != 0 {
 			return v
+		}
+	}
+	return 0
+}
+
+// getMapStr safely extracts a string from a map[string]any.
+func getMapStr(m map[string]any, k string) string {
+	if v, ok := m[k]; ok && v != nil {
+		if s, ok2 := v.(string); ok2 {
+			return s
+		}
+	}
+	return ""
+}
+
+// getMapNum safely extracts an int64 from a map[string]any, handling float64 and json.Number.
+func getMapNum(m map[string]any, k string) int64 {
+	if v, ok := m[k]; ok && v != nil {
+		switch x := v.(type) {
+		case float64:
+			return int64(x)
+		case int64:
+			return x
+		case json.Number:
+			n, _ := x.Int64()
+			return n
 		}
 	}
 	return 0


### PR DESCRIPTION
💡 **What:** Moved helper functions `getStr` and `getNum` (renamed to `getMapStr` and `getMapNum`) out of the `QueryData` loop in `pkg/backend/datasource.go`.
🎯 **Why:** Function literals defined inside a loop can cause unnecessary allocations and overhead on every iteration.
📊 **Measured Improvement:** Benchmarks (`BenchmarkAllocInLoop` vs `BenchmarkAllocOutLoop`) show similar performance (approx 44µs/op) with 0 allocations reported for both on Go 1.24. This suggests the compiler was likely already optimizing the closures, or the overhead is negligible compared to the map lookups. However, the change improves code cleanliness and prevents potential future allocation regressions if the closure logic changes. A benchmark test `pkg/backend/benchmark_test.go` has been added to the repository.

---
*PR created automatically by Jules for task [3137305289248578261](https://jules.google.com/task/3137305289248578261) started by @kljama*